### PR TITLE
Responding with the correct callback

### DIFF
--- a/lib/node_mailer.js
+++ b/lib/node_mailer.js
@@ -119,7 +119,7 @@ exports.send = function node_mail(message, callback) {
       }
       else {
         // We've started to load the template, but it's not loaded yet. queue up this message to be sent later
-        _templateCache[message.template].queue.push(message);
+        _templateCache[message.template].queue.push({message: message, callback: callback});
       }
     }
     else {
@@ -139,8 +139,11 @@ exports.send = function node_mail(message, callback) {
         _templateCache[message.template].loaded   = true;
 
         // "Drain" the queue
-        _templateCache[message.template].queue.push(message);
+        _templateCache[message.template].queue.push({message: message, callback: callback});
         _templateCache[message.template].queue.forEach(function(msg, i){
+	  var callback = msg.callback;
+	  msg = msg.message;
+
           msg.html = mustache.to_html(_templateCache[message.template].template, msg.data);
           pool.send(new EmailMessage(merge(msg,{
             to: msg.to,

--- a/lib/node_mailer.js
+++ b/lib/node_mailer.js
@@ -131,7 +131,7 @@ exports.send = function node_mail(message, callback) {
 
       fs.readFile(message.template, function(err, result){
         if (err) {
-	   _templateCache[message.template] = false;
+	  _templateCache[message.template] = false;
           callback(err);
           return;
         }

--- a/lib/node_mailer.js
+++ b/lib/node_mailer.js
@@ -131,6 +131,7 @@ exports.send = function node_mail(message, callback) {
 
       fs.readFile(message.template, function(err, result){
         if (err) {
+	   _templateCache[message.template] = false;
           callback(err);
           return;
         }

--- a/lib/node_mailer.js
+++ b/lib/node_mailer.js
@@ -140,9 +140,9 @@ exports.send = function node_mail(message, callback) {
 
         // "Drain" the queue
         _templateCache[message.template].queue.push({message: message, callback: callback});
-        _templateCache[message.template].queue.forEach(function(msg, i){
-	  var callback = msg.callback;
-	  msg = msg.message;
+        _templateCache[message.template].queue.forEach(function(queuedItem, i){
+	  var msg = queuedItem.message;
+	  var callback = queuedItem.callback;
 
           msg.html = mustache.to_html(_templateCache[message.template].template, msg.data);
           pool.send(new EmailMessage(merge(msg,{


### PR DESCRIPTION
When the messages are queued, the callbacks called once they are sent should be the ones given as argument for each email, not the one of the last email.
