### PR TITLE
Added attachment support based off of nodemailer's attachment support

### DIFF
--- a/lib/node_mailer.js
+++ b/lib/node_mailer.js
@@ -113,6 +113,7 @@ exports.send = function node_mail(message, callback) {
           sender: message.from,
           subject: message.subject,
           html: message.html,
+          attachments: message.attachments,
           server: server,
           debug: message.debug
         })), callback);
@@ -147,6 +148,7 @@ exports.send = function node_mail(message, callback) {
             sender: msg.from,
             subject: msg.subject,
             html: msg.html,
+            attachments: message.attachments,
             server: server,
             debug: msg.debug
           })), callback);
@@ -165,6 +167,7 @@ exports.send = function node_mail(message, callback) {
       subject: message.subject,
       body: message.body,
       html: message.html,
+      attachments: message.attachments,
       server: server,
       debug: message.debug
     })), callback);


### PR DESCRIPTION
A simple change, but works. Might need more testing, but since this is basically a wrapper (with some good enhancements) it should work as long as nodemailer supports attachments (which it does).
