### PR TITLE
Pass the correct callback to dispatchMail

### DIFF
--- a/lib/node_mailer.js
+++ b/lib/node_mailer.js
@@ -86,6 +86,7 @@ function merge(x,y) {
 var pool = new SMTPClientPool();
 
 exports.send = function node_mail(message, callback) {
+  message._callback = callback;
   var server = {
     host: message.host,
     hostname: message.domain,
@@ -147,7 +148,7 @@ exports.send = function node_mail(message, callback) {
         _templateCache[message.template].queue.push(message);
         _templateCache[message.template].queue.forEach(function(msg, i){
           msg.html = mustache.to_html(_templateCache[message.template].template, msg.data);
-          dispatchMail(msg, server, callback);
+          dispatchMail(msg, server, msg._callback);
         });
 
         // Clear the queue out


### PR DESCRIPTION
If several messages got queued up during the `fs.readFile` call for a single template, when the template was finally loaded, `dispatchMail` would get called for each message, but would get passed the callback associated with the first one (the only one that invoked the `fs.readFile` call). This bundles the callback in with the message itself, ensuring that the callback associated with that message is the one passed to `dispatchMail`
